### PR TITLE
Add marketing homepage with smooth transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Whatsong</title>
+  <script type="module" src="/src/main.js"></script>
+</head>
+<body>
+  <header class="hero">
+    <h1>Whatsong</h1>
+    <p>Your soundtrack companion.</p>
+    <a href="#features" class="cta">Learn More</a>
+  </header>
+  <section id="features" class="features">
+    <div class="feature">
+      <h2>Instant Recognition</h2>
+      <p>Identify any song playing around you in seconds.</p>
+    </div>
+    <div class="feature">
+      <h2>Create Playlists</h2>
+      <p>Save recognized songs to curated playlists ready to share.</p>
+    </div>
+    <div class="feature">
+      <h2>Share with Friends</h2>
+      <p>Show off your musical discoveries on social media.</p>
+    </div>
+  </section>
+  <footer class="footer">
+    <p>&copy; 2024 Whatsong. All rights reserved.</p>
+  </footer>
+</body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,14 @@
+import './style.css';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const observer = new IntersectionObserver((entries, obs) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        obs.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.2 });
+
+  document.querySelectorAll('.feature').forEach(feature => observer.observe(feature));
+});

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,80 @@
+:root {
+  --accent: #1DB954;
+  --dark: #191414;
+  --light: #ffffff;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+}
+
+body {
+  color: var(--light);
+  background: linear-gradient(135deg, var(--accent), var(--dark));
+  scroll-behavior: smooth;
+}
+
+.hero {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem;
+  opacity: 0;
+  animation: fadeIn 1s ease-in forwards;
+}
+
+.cta {
+  margin-top: 2rem;
+  padding: 0.75rem 1.5rem;
+  background: var(--light);
+  color: var(--dark);
+  border-radius: 4px;
+  text-decoration: none;
+  transition: background 0.3s ease;
+}
+
+.cta:hover {
+  background: #f0f0f0;
+}
+
+.features {
+  padding: 4rem 2rem;
+  display: grid;
+  gap: 2rem;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.feature {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 2rem;
+  border-radius: 8px;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.feature.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem;
+  opacity: 0;
+  animation: fadeIn 1s ease-in forwards;
+  animation-delay: 0.5s;
+}
+
+@keyframes fadeIn {
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- create a simple marketing-focused landing page
- add CSS design and smooth fade-in transitions
- animate feature sections on scroll for a polished experience

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: vite: not found)
- attempted to install vite but access to npm registry was forbidden

------
https://chatgpt.com/codex/tasks/task_b_6897001d45d8832b8c3650153453ff95