### PR TITLE
Add basic browser game with Spotify search

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin - What's That Song?</title>
+    <link rel="stylesheet" href="style.css">
+    <script defer src="admin.js"></script>
+</head>
+<body>
+    <h1>Admin Panel</h1>
+    <div id="login" class="section">
+        <button id="loginBtn">Login with Spotify</button>
+    </div>
+    <div id="game" class="section hidden">
+        <div>
+            <input type="text" id="search" placeholder="Search songs">
+            <button id="searchBtn">Search</button>
+        </div>
+        <ul id="results"></ul>
+        <h2>Current Track: <span id="currentTrack">None</span></h2>
+        <button id="revealBtn">Reveal Song</button>
+        <div class="groups">
+            <button id="group1Btn">קבוצה 1</button>
+            <button id="group2Btn">קבוצה 2</button>
+        </div>
+        <div class="scores">
+            <span>קבוצה 1: <span id="score1">0</span></span>
+            <span>קבוצה 2: <span id="score2">0</span></span>
+        </div>
+    </div>
+</body>
+</html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,0 +1,78 @@
+const loginBtn = document.getElementById('loginBtn');
+const searchBtn = document.getElementById('searchBtn');
+const results = document.getElementById('results');
+const revealBtn = document.getElementById('revealBtn');
+const currentTrack = document.getElementById('currentTrack');
+const group1Btn = document.getElementById('group1Btn');
+const group2Btn = document.getElementById('group2Btn');
+const score1 = document.getElementById('score1');
+const score2 = document.getElementById('score2');
+const gameSection = document.getElementById('game');
+
+let accessToken = sessionStorage.getItem('spotify_token');
+let current = null;
+let scores = { group1: 0, group2: 0 };
+
+function updateScores() {
+    score1.textContent = scores.group1;
+    score2.textContent = scores.group2;
+}
+
+function reveal() {
+    if (current) {
+        currentTrack.textContent = `${current.name} - ${current.artists[0].name}`;
+    }
+}
+
+function choose(track) {
+    current = track;
+    currentTrack.textContent = 'Hidden';
+    results.innerHTML = '';
+}
+
+function search() {
+    const q = document.getElementById('search').value;
+    fetch(`https://api.spotify.com/v1/search?type=track&q=${encodeURIComponent(q)}`, {
+        headers: { Authorization: `Bearer ${accessToken}` }
+    })
+    .then(r => r.json())
+    .then(data => {
+        results.innerHTML = '';
+        data.tracks.items.forEach(t => {
+            const li = document.createElement('li');
+            li.textContent = `${t.name} - ${t.artists[0].name}`;
+            li.onclick = () => choose(t);
+            results.appendChild(li);
+        });
+    });
+}
+
+function login() {
+    const clientId = 'YOUR_SPOTIFY_CLIENT_ID';
+    const redirectUri = location.origin + '/admin.html';
+    const scopes = 'user-read-private';
+    const authUrl = `https://accounts.spotify.com/authorize?response_type=token&client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent(scopes)}`;
+    location.href = authUrl;
+}
+
+function checkToken() {
+    const hash = location.hash.substring(1);
+    const params = new URLSearchParams(hash);
+    if (params.get('access_token')) {
+        accessToken = params.get('access_token');
+        sessionStorage.setItem('spotify_token', accessToken);
+        history.replaceState(null, '', location.pathname);
+    }
+    if (accessToken) {
+        document.getElementById('login').classList.add('hidden');
+        gameSection.classList.remove('hidden');
+    }
+}
+
+loginBtn.onclick = login;
+searchBtn.onclick = search;
+revealBtn.onclick = reveal;
+group1Btn.onclick = () => { scores.group1++; updateScores(); };
+group2Btn.onclick = () => { scores.group2++; updateScores(); };
+
+checkToken();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>What's That Song?</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>What's That Song?</h1>
+        <button onclick="location.href='admin.html'">Admin</button>
+        <button onclick="location.href='player.html'">Join Game</button>
+    </div>
+</body>
+</html>

--- a/public/player.html
+++ b/public/player.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Player - What's That Song?</title>
+    <link rel="stylesheet" href="style.css">
+    <script defer src="player.js"></script>
+</head>
+<body>
+    <h1>Join Game</h1>
+    <div class="section">
+        <label>Team Name: <input type="text" id="teamName"></label>
+        <button id="saveName">Save</button>
+    </div>
+    <div class="section">
+        <h2 id="groupLabel"></h2>
+        <h3 id="trackHidden">Song Hidden</h3>
+    </div>
+    <div class="scores">
+        <span>קבוצה 1: <span id="score1">0</span></span>
+        <span>קבוצה 2: <span id="score2">0</span></span>
+    </div>
+</body>
+</html>

--- a/public/player.js
+++ b/public/player.js
@@ -1,0 +1,41 @@
+const groupLabel = document.getElementById('groupLabel');
+const trackHidden = document.getElementById('trackHidden');
+const teamNameInput = document.getElementById('teamName');
+const saveNameBtn = document.getElementById('saveName');
+const score1 = document.getElementById('score1');
+const score2 = document.getElementById('score2');
+
+let group = localStorage.getItem('group');
+let name = localStorage.getItem('teamName') || '';
+teamNameInput.value = name;
+
+function updateScores(data) {
+    score1.textContent = data.group1;
+    score2.textContent = data.group2;
+}
+
+function connect() {
+    const evt = new EventSource('/events');
+    evt.onmessage = e => {
+        const msg = JSON.parse(e.data);
+        if (msg.type === 'assign') {
+            group = msg.group;
+            localStorage.setItem('group', group);
+            groupLabel.textContent = group === 'group1' ? 'קבוצה 1' : 'קבוצה 2';
+        } else if (msg.type === 'reveal') {
+            trackHidden.textContent = msg.track;
+        } else if (msg.type === 'scores') {
+            updateScores(msg);
+        }
+    };
+    evt.onerror = () => console.log('connection error');
+}
+
+function saveName() {
+    name = teamNameInput.value;
+    localStorage.setItem('teamName', name);
+    fetch('/name', { method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify({ group, name }) });
+}
+
+saveNameBtn.onclick = saveName;
+connect();

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,29 @@
+body {
+    background: #f5fff5;
+    font-family: Arial, sans-serif;
+    color: #191414;
+    margin: 0;
+    padding: 0;
+    text-align: center;
+}
+
+.container {
+    margin-top: 50px;
+}
+
+button {
+    background: #1db954;
+    border: none;
+    padding: 10px 20px;
+    color: white;
+    margin: 5px;
+    cursor: pointer;
+}
+
+.hidden { display: none; }
+
+.section { margin: 20px; }
+
+.groups button { margin: 5px; }
+
+.scores { margin-top: 20px; }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,69 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+let clients = [];
+let scores = { group1: 0, group2: 0 };
+let nextGroup = 'group1';
+let currentTrack = '';
+
+function sendAll(data) {
+    clients.forEach(res => res.write(`data: ${JSON.stringify(data)}\n\n`));
+}
+
+const server = http.createServer((req, res) => {
+    const parsed = url.parse(req.url, true);
+    if (req.method === 'GET' && parsed.pathname === '/events') {
+        res.writeHead(200, {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            'Connection': 'keep-alive'
+        });
+        const group = nextGroup;
+        nextGroup = nextGroup === 'group1' ? 'group2' : 'group1';
+        res.write(`data: ${JSON.stringify({ type: 'assign', group })}\n\n`);
+        clients.push(res);
+        req.on('close', () => { clients = clients.filter(c => c !== res); });
+    } else if (req.method === 'POST' && parsed.pathname === '/name') {
+        let body = '';
+        req.on('data', chunk => body += chunk);
+        req.on('end', () => {
+            const { group, name } = JSON.parse(body);
+            // Could store name per group
+            res.writeHead(200); res.end('ok');
+        });
+    } else if (req.method === 'POST' && parsed.pathname === '/reveal') {
+        let body = '';
+        req.on('data', c => body += c);
+        req.on('end', () => {
+            const { track } = JSON.parse(body);
+            currentTrack = track;
+            sendAll({ type: 'reveal', track });
+            res.writeHead(200); res.end('ok');
+        });
+    } else if (req.method === 'POST' && parsed.pathname === '/score') {
+        let body = '';
+        req.on('data', c => body += c);
+        req.on('end', () => {
+            const { group } = JSON.parse(body);
+            scores[group]++;
+            sendAll({ type: 'scores', ...scores });
+            res.writeHead(200); res.end('ok');
+        });
+    } else {
+        let filePath = path.join(__dirname, 'public', parsed.pathname === '/' ? 'index.html' : parsed.pathname);
+        fs.readFile(filePath, (err, data) => {
+            if (err) {
+                res.writeHead(404); res.end('Not found');
+            } else {
+                const ext = path.extname(filePath);
+                const type = ext === '.js' ? 'text/javascript' : ext === '.css' ? 'text/css' : 'text/html';
+                res.writeHead(200, { 'Content-Type': type });
+                res.end(data);
+            }
+        });
+    }
+});
+
+server.listen(3000, () => console.log('Server running on http://localhost:3000'));


### PR DESCRIPTION
## Summary
- create static frontend with admin & player screens
- implement Spotify login and track search via browser
- allow players to edit team names and view scores
- add simple Node server using SSE for group assignment and score updates

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_b_688681422d64832bb8877a1d84ae13cc